### PR TITLE
表紙の画像ファイルパスのリストアップ機能を追加

### DIFF
--- a/ScanSnapImageOrganizer/Sources/IO/FileNameFilter.cs
+++ b/ScanSnapImageOrganizer/Sources/IO/FileNameFilter.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+
+namespace ScanSnapImageOrganizer.IO
+{
+    //! @brief ファイル名のリストのフィルター
+    internal class FileNameFilter
+    {
+        private string _sequentialFileNamePattern; //! @brief 連番が振られている(2ページ目以降の)ファイル名のパターン(正規表現)
+
+        //! @brief コンストラクタ
+        //! 
+        //! @param[in] newNumberFileNamePattern 連番が振られている(2ページ目以降の)ファイル名のパターン(正規表現)
+        public FileNameFilter(string newSequentialFileNamePattern)
+        {
+            _sequentialFileNamePattern = newSequentialFileNamePattern;
+        }
+
+        //! @brief タイトルが書かれたファイルのパスをリストアップする
+        //! 
+        //! @param[in] targetFileNameList 走査対象のファイルパスのリスト
+        //! 
+        //! @return タイトルのファイルパスのリスト
+        public List<string> ListTitleFilePaths(in List<string> targetFilePathList)
+        {
+            var regex = new Regex(_sequentialFileNamePattern, RegexOptions.IgnoreCase);
+            return targetFilePathList.Where(element => regex.IsMatch(element) == false).ToList();
+        }
+    }
+}

--- a/ScanSnapImageOrganizer/Sources/Program.cs
+++ b/ScanSnapImageOrganizer/Sources/Program.cs
@@ -1,10 +1,34 @@
-﻿namespace ScanSnapImageOrganizer
+using System.Reflection;
+
+namespace ScanSnapImageOrganizer
 {
     internal class Program
     {
         private static void Main(string[] args)
         {
+#if DEBUG
+            var unitTester = new Test.UnitTester();
+            unitTester.TestAll();
+#endif
+
+            //画像ファイルのパスのリストを取得
+            //特に指定がない限り、フォルダ分けしたいフォルダに放り込む使い方を想定
+            var targetDirectoryPath = 0 < args.Length ? args[0] : "";
+            if (string.IsNullOrEmpty(targetDirectoryPath) || string.IsNullOrWhiteSpace(targetDirectoryPath))
+            {
+                targetDirectoryPath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            }
+            var allImageFilePaths = Directory.GetFiles(targetDirectoryPath, @"*.jpg").ToList();
             
+            //各本の表紙のリストを取得
+            var filter = new IO.FileNameFilter(@".*_[0-9]{3}\.jpg");
+            var titleFilePaths = filter.ListTitleFilePaths(allImageFilePaths);
+
+
+            Console.WriteLine("ScanSnapで生成した画像ファイルのフォルダ分けを開始します");
+            Console.WriteLine($"今回の実行時間：{DateTime.Now}");
+            Console.WriteLine($"フォルダ分け対象のディレクトリ：{targetDirectoryPath}");
+            Console.WriteLine("ScanSnapで生成した画像ファイルのフォルダ分けを完了しました");
         }
     }
 }

--- a/ScanSnapImageOrganizer/Sources/Test/UnitTester.cs
+++ b/ScanSnapImageOrganizer/Sources/Test/UnitTester.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics;
+
+namespace ScanSnapImageOrganizer.Test
+{
+    //! @brief 単体テストのテスター
+    internal class UnitTester
+    {
+        //! @brief 単体テストを全て行う
+        public void TestAll()
+        {
+#if DEBUG
+            TestFileNameFilter();
+#endif
+        }
+
+        //! @brief FileNameFilterの関数の単体テストを行う
+        public void TestFileNameFilter()
+        {
+#if DEBUG
+            //正規表現が間違っていた場合ヒットしないかのテスト
+            var filter = new IO.FileNameFilter(@"");
+            var testFilePathList = new List<string>() { "TestFilePath.jpg", "TestFilePath_000.jpg", "TestFilePath_001.jpg" };
+            Debug.Assert(filter.ListTitleFilePaths(testFilePathList).Count == 0);
+
+            //与えた正規表現できちんとヒットするかどうかのテスト
+            filter = new IO.FileNameFilter(@".*_[0-9]{3}\.jpg");
+            Debug.Assert(filter.ListTitleFilePaths(testFilePathList).Count == 1);
+#endif
+        }
+    }
+}


### PR DESCRIPTION
# 概要

表題通り、スキャンした本の表紙の画像のリストアップ機能の追加  
また、上記の単体テストも追加  
さらに、上記を用いるMainの処理も追加